### PR TITLE
Fix README links and add import guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ A collection of useful blueprints for Home Assistant automations, crafted to mak
 2. Click **Import Blueprint** and paste the **raw GitHub URL** to the `.yaml` file.
 3. Use the blueprint to create automations in Home Assistant.
 
-📘 See [docs/how-to-import.md](./docs/how-to-import.md) for more help.
+📘 See [docs/how_to_import.md](./docs/how_to_import.md) for more help.
 

--- a/blueprints/automation/smarttecharabic/azan-notifications/README.md
+++ b/blueprints/automation/smarttecharabic/azan-notifications/README.md
@@ -27,7 +27,7 @@ Make sure the following are in place before using this blueprint:
 
 Click the button below to import the blueprint directly into your Home Assistant instance:
 
-[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fshadynafie%2FAzanNotification%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Fshadynafie%2Fazan_notifications.yaml)
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fshadynafie%2Fhome-assistant-blueprints%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Fsmarttecharabic%2Fazan-notifications%2Fazan_notifications.yaml)
 
 ---
 
@@ -66,7 +66,7 @@ You can personalise the message shown in each prayer notification.
 
 ## 📷 Screenshots
 
-![Preview](https://github.com/shadynafie/AzanNotification/blob/main/assets/mobile-notofication-preview.png)
+![Preview](../../../../docs/images/azan_notification_preview.png)
 
 ---
 

--- a/blueprints/automation/smarttecharabic/people-tracking/README.md
+++ b/blueprints/automation/smarttecharabic/people-tracking/README.md
@@ -32,7 +32,7 @@ It fires custom actions when any person:
 
 Below is a visual overview of the blueprint in action, showing how it monitors multiple people across multiple zones.
 
-![Preview](https://github.com/shadynafie/PersonZoneMonitor/raw/main/assets/preview.png)
+![Preview](../../../../docs/images/person_zone_monitor_preview.png)
 
 ---
 
@@ -40,7 +40,7 @@ Below is a visual overview of the blueprint in action, showing how it monitors m
 
 Click the button below to import this blueprint directly into your Home Assistant instance.
 
-[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fshadynafie%2FPersonZoneMonitor%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Fshadynafie%2Fperson_zone_monitor.yaml)
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fshadynafie%2Fhome-assistant-blueprints%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Fsmarttecharabic%2Fpeople-tracking%2Fperson_zone_monitor.yaml)
 
 ---
 

--- a/docs/how_to_import.md
+++ b/docs/how_to_import.md
@@ -1,0 +1,10 @@
+# How to Import Home Assistant Blueprints
+
+Follow these steps to import a blueprint from this repository into your Home Assistant instance.
+
+1. Open **Settings** in Home Assistant.
+2. Navigate to **Automations & Scenes** and choose **Blueprints**.
+3. Click **Import Blueprint**.
+4. Paste the raw GitHub URL of the `.yaml` file you want to use from this repository.
+5. Confirm and then create your automation based on the imported blueprint.
+


### PR DESCRIPTION
## Summary
- update README with correct docs path
- fix blueprint READMEs to use local import URLs and preview images
- add a simple docs/how_to_import.md help file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d2e58dc80832594ee7ae167a10c91