### PR TITLE
Fix license link

### DIFF
--- a/blueprints/automation/smarttecharabic/people-tracking/README.md
+++ b/blueprints/automation/smarttecharabic/people-tracking/README.md
@@ -50,4 +50,4 @@ Need help? Watch [Smart Tech Arabic](https://www.youtube.com/@smarttecharabic) f
 
 ## 📄 License
 
-This project is licensed under the [MIT License](LICENSE).
+This project is licensed under the [MIT License](../../../../LICENSE.txt).


### PR DESCRIPTION
## Summary
- update MIT license link in people tracking blueprint README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d398ad690832588d58bfb10c57772